### PR TITLE
Inaprov OD fix

### DIFF
--- a/code/modules/medical/cloning.dm
+++ b/code/modules/medical/cloning.dm
@@ -298,7 +298,7 @@
 
 			//So clones don't die of oxyloss in a running pod.
 			if (src.occupant.reagents.get_reagent_amount("inaprovaline") < 30)
-				src.occupant.reagents.add_reagent("inaprovaline", 60)
+				src.occupant.reagents.add_reagent("inaprovaline", 30)
 
 			var/mob/living/carbon/human/H = src.occupant
 


### PR DESCRIPTION
Inaprovaline was killing unattended cloning patients, this fixes that.

Previously, Cloning.dm would check to see how much inaprovaline you had in your system, and if it was less than thirty, it'd inject you with 60 units.

This would put you at 89, over the OD threshold, which is sixty.
This fix will change it so if you have less than 30, it'll inject you with 30 more. This will put you at 59, keeping you from ODing, but keeping inaprovaline in your system so you don't die from oxyloss.
